### PR TITLE
Thesis #3: Reduce allocations in MatchRecord.entries()

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -41,12 +41,10 @@ export class MatchRecord {
     this.store.set(target, current === undefined ? n : n & current)
   }
   // match, absolute, ifdir
-  entries(): [Path, boolean, boolean][] {
-    return [...this.store.entries()].map(([path, n]) => [
-      path,
-      !!(n & 2),
-      !!(n & 1),
-    ])
+  *entries(): Generator<[Path, boolean, boolean]> {
+    for (const [path, n] of this.store.entries()) {
+      yield [path, !!(n & 2), !!(n & 1)]
+    }
   }
 }
 


### PR DESCRIPTION
References #3

Self-reported metric: 98858.4400
Baseline: 96763.9500
Summary: Converted MatchRecord.entries() to generator function, eliminating array allocation. 2.16% improvement.